### PR TITLE
feat: add mysql connector and flyway's mysql integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>8.0.32</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
@@ -36,6 +41,10 @@
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-mysql</artifactId>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Claudia, tive um pouco de dificuldade pra rodar o projeto e só consegui após os dois passos abaixo:

1) Inclusão da dependência do driver do MySQL; e
2) Inclusão da dependência da integração do Flyway com o MySQL - nesse caso foi necessário pois utilizei a versão mais nova do MYSQL (8.0.32)


Faz sentido essas sugestões ?